### PR TITLE
Create output directory if it doesn't exist, make script executable.

### DIFF
--- a/generated/.gitignore
+++ b/generated/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
I've added a check to create the output dir if it doesn't exist. That way, you can make it configurable, or remove it from the repo if you want, so tab completion doesn't trip itself over the two similarly-named dirs all the time. I've also made the script executable.
