### PR TITLE
Added proxy settings for Amazon Instant Video US

### DIFF
--- a/proxies/proxies-us.json
+++ b/proxies/proxies-us.json
@@ -860,5 +860,27 @@
         "dnat": false
       }
     ]
+  },
+  "amazon": {
+    "proxies": [
+      {
+        "alias":"amazon_atv-ps",
+        "domain":"atv-ps.amazon.com",
+        "protocols": ["http", "https"],
+        "dnat": true
+      },
+      {
+        "alias":"amazon_atv-ext",
+        "domain":"atv-ext.amazon.com",
+        "protocols": ["http", "https"],
+        "dnat": false
+      },
+      {
+        "alias":"amazon_atv",
+        "domain":"atv.amazon.com",
+        "protocols": ["http", "https"],
+        "dnat": true
+      }
+    ]
   }
 }


### PR DESCRIPTION
I have added proxy settings for Amazon Instant Video US, untested but equivalent to Germany, and as discussed in #9.