### PR TITLE
DNAT mode improvements

### DIFF
--- a/config-sample.json
+++ b/config-sample.json
@@ -1,11 +1,13 @@
 {
-  "iptables_location": "iptables", // Required to generate iptables rules
+  "iptables_location": "iptables", // Required to generate iptables rules in mode "dnat"
   "bind_ip": "*", // The IP address to bind to
   "public_ip": "", // IP address of your remote server, required for every mode
   "base_ip": "",
-  // "base_ip": "x.x.x.x", // Only required for modes "non-sni" and "local"
+  // "base_ip": "x.x.x.x", // Only required for modes "dnat" and "local"
   // "base_ip": "127.0.0.51", // For local
-  "base_port": 27200, // Only required for mode "non-sni"
+  "base_port": 27200, // Only required for mode "dnat"
+  // "local_subnet": 24, // Only required for mode "dnat"
+  // "local_device": "eth1", // Only required for mode "dnat"
   "server_options": "check inter 10s fastinter 2s downinter 2s fall 1800", // Don't touch unless you know what you're doing
   "stats": {
     "enabled": true, // Set to true to enable HAProxy stats web page

--- a/generators/__init__.py
+++ b/generators/__init__.py
@@ -2,6 +2,7 @@
 from haproxy import generate as generate_haproxy
 from dnsmasq import generate as generate_dnsmasq
 from iptables import generate as generate_iptables
+from iproute2 import generate as generate_iproute2
 from hosts import generate as generate_hosts
 from netsh import generate as generate_netsh
 from rinetd import generate as generate_rinetd

--- a/generators/dnsmasq.py
+++ b/generators/dnsmasq.py
@@ -10,7 +10,7 @@ def generate(config, dnat=False, test=True):
         if not dnat:
             c = chunks([proxy["domain"] for proxy in group["proxies"]], 5)
         else:
-            c = chunks([proxy["domain"] for proxy in group["proxies"] if proxy["dnat"]], 5)
+            c = chunks([proxy["domain"] for proxy in group["proxies"] if not proxy["dnat"]], 5)
 
         for chunk in c:
             if not dnat:
@@ -29,7 +29,7 @@ def generate(config, dnat=False, test=True):
     if dnat:
         for group in config["groups"].values():
             for proxy in group["proxies"]:
-                if not proxy["dnat"]:
+                if proxy["dnat"]:
                     current_ip = long2ip(ip2long(current_ip) + 1)
                     dnsmasq_content += generate_dns(proxy["domain"], current_ip)
 

--- a/generators/haproxy.py
+++ b/generators/haproxy.py
@@ -31,7 +31,7 @@ def generate(config, dnat=False, test=True):
 
     for group in config["groups"].values():
         for proxy in group["proxies"]:
-            if not dnat or (dnat and proxy["dnat"]):
+            if not dnat or (dnat and not proxy["dnat"]):
                 for protocol in proxy["protocols"]:
                     if protocol == 'http':
                         haproxy_catchall_frontend_content += generate_frontend_catchall_entry(proxy["domain"], protocol)

--- a/generators/hosts.py
+++ b/generators/hosts.py
@@ -10,7 +10,7 @@ def generate(config, dnat=False, test=True):
         for proxy in group["proxies"]:
             if not dnat:
                 add_hosts(hosts, proxy["domain"], public_ip)
-            elif proxy["dnat"]:
+            elif not proxy["dnat"]:
                 add_hosts(hosts, proxy["domain"], current_ip)
 
     if test:
@@ -23,7 +23,7 @@ def generate(config, dnat=False, test=True):
     if dnat:
         for group in config["groups"].values():
             for proxy in group["proxies"]:
-                if not proxy["dnat"]:
+                if proxy["dnat"]:
                     current_ip = long2ip(ip2long(current_ip) + 1)
                     add_hosts(hosts, proxy["domain"], current_ip)
 

--- a/generators/iproute2.py
+++ b/generators/iproute2.py
@@ -1,0 +1,21 @@
+import os
+from util import long2ip, ip2long
+
+
+def generate(config):
+    current_ip = config["base_ip"]
+    local_subnet = config["local_subnet"]
+    local_device = config["local_device"]
+
+    iproute2_content = generate_iproute2(current_ip, local_subnet, local_device)
+    for group in config["groups"].values():
+        for proxy in group["proxies"]:
+            if proxy["dnat"]:
+                current_ip = long2ip(ip2long(current_ip) + 1)
+                iproute2_content += generate_iproute2(current_ip, local_subnet, local_device)
+    return iproute2_content
+
+
+def generate_iproute2(current_dnat_ip, subnet, device):
+    result = 'ip addr add ' + current_dnat_ip + '/' + str(subnet) + ' dev ' + device + os.linesep
+    return result

--- a/generators/iptables.py
+++ b/generators/iptables.py
@@ -24,5 +24,4 @@ def generate(config):
 
 def generate_iptables(port, public_ip, current_dnat_ip, current_dnat_port, iptables_location):
     result = iptables_location + ' -t nat -A PREROUTING -p tcp --dport ' + str(port) + ' -d ' + current_dnat_ip + ' -j DNAT --to-destination ' + public_ip + ':' + str(current_dnat_port) + os.linesep
-    result += iptables_location + ' -t nat -A POSTROUTING -p tcp --dport ' + str(current_dnat_port) + ' -j MASQUERADE' + os.linesep
     return result


### PR DESCRIPTION
The commits improve the DNAT mode as discussed in #9.

I’ve added a generator for the iproute2 tool to add the needed ip addresses to the local device.
The MASQUERADE lines in the iptables config are not necessary in my opinion: If the forwarder is run on the router, it usually does masquerading by itself; if the forwarder is an additional device then to networks router is usually doing masquerading and the responses go directly back to the requesting device.
All the other changes are only adjustments to take the right hosts into account for config file creation.

It is working fine for me in this setup.

Feel free to give feedback :)