### PR TITLE
Initial Polish proxies support; Ipla.tv

### DIFF
--- a/proxies/proxies-pl.json
+++ b/proxies/proxies-pl.json
@@ -1,0 +1,12 @@
+{
+  "ipla.tv": {
+    "proxies": [
+      {
+        "alias":"redefine-getmedia",
+        "domain":"getmedia.redefine.pl",
+        "protocols": ["http", "https"],
+        "dnat": false
+      }
+    ]
+  }
+}

--- a/proxies/proxies-pl.json
+++ b/proxies/proxies-pl.json
@@ -8,5 +8,21 @@
         "dnat": false
       }
     ]
+  },
+  "tvp": {
+    "proxies": [
+      {
+        "alias":"tvp-vod",
+        "domain":"vod.tvp.pl",
+        "protocols": ["http", "https"],
+        "dnat": false
+      },
+      {
+        "alias":"tvp-stream",
+        "domain":"tvpstream.tvp.pl",
+        "protocols": ["http", "https"],
+        "dnat": false
+      }
+    ]
   }
 }


### PR DESCRIPTION
Initial support for Polish VOD media. Allows to watch ipla.tv platform content.